### PR TITLE
Embed Hyperscript using ST4114+ scheme

### DIFF
--- a/HTML (Hyperscript).sublime-syntax
+++ b/HTML (Hyperscript).sublime-syntax
@@ -9,15 +9,37 @@ extends: Packages/HTML/HTML.sublime-syntax
 contexts:
   script-hyperscript:
     - meta_scope: meta.tag.script.begin.html
-    - include: script-common
     - match: '>'
       scope: punctuation.definition.tag.end.html
-      set:
-        - include: script-close-tag
-        - match: (?=\S)
-          embed: scope:source.hyperscript
-          embed_scope: source.hyperscript.embedded.html
-          escape: (?i)(?=(?:-->\s*)?</script)
+      set: script-hyperscript-content
+    - include: script-common
+
+  script-hyperscript-content:
+    - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.hyperscript
+      embed_scope: meta.tag.sgml.cdata.html source.hyperscript.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.hyperscript
+      embed_scope: source.hyperscript.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.hyperscript.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.hyperscript.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
 
   script-type-decider:
     - meta_prepend: true


### PR DESCRIPTION
This commit...

1. applies a fix for comment toggling which shipps with ST4114+.
2. adds support for enclosing script content in <![CDATA[ ... ]]>,
   which was found to be used by some templating engines (e.g.: JSP)
   sometimes.
3. moves `script-common` include to ensure compatibility with future
   changes to HTML.
   (note: not yet applied to official HTML.sublime-syntax)


Note: This commit requires ST4114. To keep the current solution available for older builds, some changes to `package_control_channel` would be required.

Different variants for ST may be provided using tag prefixes. A common scheme along recent packages is to use least required ST build number. 

- tag `4107-1.x.x` for current master with "old" solution.

- tag `4114-1.x.x` for branch with this PR merged in. 

package_control_channel can than be used to limit those tags to certain builds.